### PR TITLE
Adding exit codes to rescue blocks

### DIFF
--- a/lib/rightscale_selfservice/cli/execution.rb
+++ b/lib/rightscale_selfservice/cli/execution.rb
@@ -41,6 +41,7 @@ module RightScaleSelfService
           shell = Thor::Shell::Color.new
           message = "Failed to list executions\n\n#{RightScaleSelfService::Api::Client.format_error(e)}"
           logger.error(shell.set_color message, :red)
+          exit 1
         end
       end
 
@@ -62,6 +63,7 @@ module RightScaleSelfService
           shell = Thor::Shell::Color.new
           message = "Failed to show execution id #{id}\n\n#{RightScaleSelfService::Api::Client.format_error(e)}"
           logger.error(shell.set_color message, :red)
+          exit 1
         end
       end
 

--- a/lib/rightscale_selfservice/cli/operation.rb
+++ b/lib/rightscale_selfservice/cli/operation.rb
@@ -42,6 +42,7 @@ module RightScaleSelfService
           shell = Thor::Shell::Color.new
           message = "Failed to create operation \"#{operation_name}\" on execution id \"#{execution_id}\"\n\n#{RightScaleSelfService::Api::Client.format_error(e)}"
           logger.error(shell.set_color message, :red)
+          exit 1
         end
       end
 
@@ -68,6 +69,7 @@ module RightScaleSelfService
           shell = Thor::Shell::Color.new
           message = "Failed to list operations\n\n#{RightScaleSelfService::Api::Client.format_error(e)}"
           logger.error(shell.set_color message, :red)
+          exit 1
         end
       end
     end

--- a/lib/rightscale_selfservice/cli/template.rb
+++ b/lib/rightscale_selfservice/cli/template.rb
@@ -53,6 +53,7 @@ module RightScaleSelfService
           shell = Thor::Shell::Color.new
           message = "Failed to compile template\n\n#{RightScaleSelfService::Api::Client.format_error(e)}"
           logger.error(shell.set_color message, :red)
+          exit 1
         end
       end
 
@@ -94,6 +95,7 @@ module RightScaleSelfService
           shell = Thor::Shell::Color.new
           message = "Failed to update or create template\n\n#{RightScaleSelfService::Api::Client.format_error(e)}"
           logger.error(shell.set_color message, :red)
+          exit 1
         ensure
           tmpfile.close!()
         end
@@ -128,10 +130,12 @@ module RightScaleSelfService
             rescue RestClient::ExceptionWithResponse => e
               message = "Failed to get a list of existing published templates\n\n#{RightScaleSelfService::Api::Client.format_error(e)}"
               logger.error(shell.set_color message, :red)
+              exit 1
             end
           else
             message = "Failed to publish template\n\n#{RightScaleSelfService::Api::Client.format_error(e)}"
             logger.error(shell.set_color message, :red)
+            exit 1
           end
         end
       end
@@ -153,6 +157,7 @@ module RightScaleSelfService
           shell = Thor::Shell::Color.new
           message = "Failed to list templates\n\n#{RightScaleSelfService::Api::Client.format_error(e)}"
           logger.error(shell.set_color message, :red)
+          exit 1
         end
       end
 
@@ -178,6 +183,7 @@ module RightScaleSelfService
           shell = Thor::Shell::Color.new
           message = "Failed to create execution from template\n\n#{RightScaleSelfService::Api::Client.format_error(e)}"
           logger.error(shell.set_color message, :red)
+          exit 1
         end
       end
 


### PR DESCRIPTION
This tool is great but difficult to use with a CI system because it often exits successfully, even when errors are encountered.

This patch exits 1 in a few places where exceptions are handled.  I was not entirely sure how to extend test coverage for this so I didn't :sunglasses: 
