### PR TITLE
TL-434 fix reference to old rs_api_docs bucket

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -55,7 +55,7 @@ end
 desc "Scrapes the current API docs to determine the current interface and put it in a json file"
 task :update_interface_json do
   log = Logger.new(STDOUT)
-  base_url = "https://s3.amazonaws.com/rs_api_docs/selfservice"
+  base_url = "http://reference.rightscale.com/selfservice"
   services = ["catalog","designer","manager"]
   hashything = {:services => Hash[services.map{|s| [s, {}]}]}
   services.each do |service|

--- a/lib/rightscale_selfservice/cli/operation.rb
+++ b/lib/rightscale_selfservice/cli/operation.rb
@@ -46,7 +46,7 @@ module RightScaleSelfService
       end
 
       desc "list", "Lists all operations, optionally filtered by --filter and/or --property"
-      option :filter, :type => :array, :desc => "Filters to apply see (https://s3.amazonaws.com/rs_api_docs/selfservice/manager/index.html#/1.0/controller/V1::Controller::Operation/index)"
+      option :filter, :type => :array, :desc => "Filters to apply see (http://reference.rightscale.com/selfservice/manager/index.html#/1.0/controller/V1::Controller::Operation/index)"
       option :property, :type => :array, :desc => "When supplied, only the specified properties will be displayed. By default the entire response is supplied."
       def list()
         params = {}


### PR DESCRIPTION
We are removing old rs_api_docs bucket. This is the correct way to access this links
